### PR TITLE
chore: remove debug console.log statements from production code

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,6 @@ const AppContent = () => {
   useEffect(() => {
     // Migrate data from localStorage to IndexedDB
     migrateFromLocalStorage();
-    console.log("balados.app démarré");
   }, []);
 
   const handleNavigate = (view: string, feedUrl: string | null = null) => {

--- a/src/services/rss/parser.ts
+++ b/src/services/rss/parser.ts
@@ -72,7 +72,6 @@ export const fetchAndParseRSS = async (
   if (useCache) {
     const cached = await getCachedFeed(url);
     if (cached) {
-      console.log("Feed charge depuis le cache:", cached.title);
       return cached;
     }
   }
@@ -86,6 +85,5 @@ export const fetchAndParseRSS = async (
   // Cache the result
   await cacheFeed(url, feed);
 
-  console.log("Feed parse avec succes:", feed.title, feed.items.length, "episodes");
   return feed;
 };

--- a/src/services/rss/proxyManager.ts
+++ b/src/services/rss/proxyManager.ts
@@ -16,52 +16,41 @@ export const fetchWithProxy = async (url: string): Promise<FetchResult> => {
 
   // Try direct fetch first
   try {
-    console.log(`Tentative directe sans proxy: ${url}`);
     const response = await fetch(url);
     if (response.ok) {
       const text = await response.text();
-      console.log("Succes en direct sans proxy!");
       return { text, proxyUsed: null };
     }
-  } catch (e) {
-    const error = e as Error;
-    console.log("Echec en direct:", error.message);
+  } catch {
+    // Direct fetch failed, try proxies
   }
 
   // Try sync server proxy if configured
   if (settings.syncServerUrl && settings.syncToken) {
     try {
       const syncProxyUrl = `${settings.syncServerUrl.replace(/\/$/, "")}/api/v1/rss/proxy/${encodeRssFeed(url)}`;
-      console.log("Tentative avec Sync Server proxy");
       const response = await fetch(syncProxyUrl, {
         headers: { Authorization: `Bearer ${settings.syncToken}` },
       });
       if (response.ok) {
         const text = await response.text();
-        console.log("Succes avec Sync Server proxy!");
         return { text, proxyUsed: "Sync Server" };
-      } else {
-        console.log(`Sync Server proxy echec: status ${response.status}`);
       }
-    } catch (e) {
-      console.log("Echec avec Sync Server proxy:", (e as Error).message);
+    } catch {
+      // Sync server proxy failed, try public proxies
     }
   }
 
   // Try each proxy in order
   for (const proxy of enabledProxies) {
     try {
-      console.log(`Tentative avec proxy ${proxy.name}`);
       const proxyUrl = `${proxy.url}${encodeURIComponent(url)}`;
       const response = await fetch(proxyUrl);
       if (response.ok) {
         const text = await response.text();
-        console.log(`Succes avec ${proxy.name}`);
         return { text, proxyUsed: proxy.name };
       }
-    } catch (e) {
-      const error = e as Error;
-      console.log(`Echec avec ${proxy.name}:`, error.message);
+    } catch {
       continue;
     }
   }

--- a/src/services/storage/index.ts
+++ b/src/services/storage/index.ts
@@ -154,7 +154,6 @@ export const migrateFromLocalStorage = async (): Promise<void> => {
 
       if (existingCount === 0 && subs.length > 0) {
         await db.subscriptions.bulkPut(subs);
-        console.log(`Migrated ${subs.length} subscriptions from localStorage`);
       }
     } catch (e) {
       console.error("Failed to migrate localStorage data:", e);


### PR DESCRIPTION
## Summary

- Remove 14 `console.log` statements from 4 production files
- Keep all `console.error` / `console.warn` calls (legitimate error handling in catch blocks)
- Keep `services/debug/index.ts` untouched (it's the debug infrastructure itself)

## Files changed

| File | Removed | Kept |
|------|---------|------|
| `proxyManager.ts` | 10 `console.log` | - |
| `parser.ts` | 2 `console.log` | - |
| `App.tsx` | 1 `console.log` | - |
| `storage/index.ts` | 1 `console.log` | 1 `console.error` |

## What's kept (22 console.error/warn)

All `console.error` calls in catch blocks across `syncQueue.ts` (11), `PlayerProvider.tsx` (3), `SyncSettings.tsx` (3), `ErrorBoundary.tsx` (1), `InProgress.tsx` (1), `Stats.tsx` (1), `client.ts` (1), `storage/index.ts` (1). These are real error logging, not debug noise.

## Test plan

- [x] All 188 tests pass
- [x] Build succeeds (tsc + vite)
- [x] No `console.log` remains in production code (only in `debug/index.ts` infrastructure)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)